### PR TITLE
Fix/filter api

### DIFF
--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -99,7 +99,7 @@ const getChingus = async (req, res) => {
 
     const query = {};
 
-    // SAFE fuzzy searches
+    // SAFE regex searches (fuzzy for most fields, exact for gender)
     if (country) {
       const countries = Array.isArray(country) ? country : [country];
 

--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -22,12 +22,12 @@ const aggregateByCountry = async (req, res) => {
     if (country) {
       const countries = Array.isArray(country) ? country : [country];
 
-      matchQuery.countryName = {
-        $in: countries.map((c) => ({
-          $regex: `^${escapeRegex(c.trim())}$`,
+      matchQuery.$or = countries.map((c) => ({
+        countryName: {
+          $regex: escapeRegex(c.trim()), // fuzzy contains search
           $options: "i",
-        })),
-      };
+        },
+      }));
     }
 
     if (gender)
@@ -100,8 +100,16 @@ const getChingus = async (req, res) => {
     const query = {};
 
     // SAFE fuzzy searches
-    if (country)
-      query.countryName = { $regex: escapeRegex(country), $options: "i" };
+    if (country) {
+  const countries = Array.isArray(country) ? country : [country];
+
+  query.$or = countries.map((c) => ({
+    countryName: {
+      $regex: escapeRegex(String(c).trim()), 
+      $options: "i",
+    },
+  }));
+}
 
     if (gender) {
       query.gender = { $regex: `^${escapeRegex(gender)}$`, $options: "i" };

--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -101,15 +101,15 @@ const getChingus = async (req, res) => {
 
     // SAFE fuzzy searches
     if (country) {
-  const countries = Array.isArray(country) ? country : [country];
+      const countries = Array.isArray(country) ? country : [country];
 
-  query.$or = countries.map((c) => ({
-    countryName: {
-      $regex: escapeRegex(String(c).trim()), 
-      $options: "i",
-    },
-  }));
-}
+      query.$or = countries.map((c) => ({
+        countryName: {
+          $regex: escapeRegex(String(c).trim()), 
+          $options: "i",
+        },
+      }));
+    }
 
     if (gender) {
       query.gender = { $regex: `^${escapeRegex(gender)}$`, $options: "i" };

--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -1,8 +1,7 @@
-const Chingu = require('../models/Chingu');
+const Chingu = require("../models/Chingu");
 
 // Escape regex special characters to prevent ReDoS & regex injection
-const escapeRegex = (str) =>
-  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const aggregateByCountry = async (req, res) => {
   try {
@@ -13,21 +12,29 @@ const aggregateByCountry = async (req, res) => {
       role,
       soloProjectTier,
       voyageTier,
-      voyage,       
+      voyage,
       yearJoined,
     } = req.query;
 
     const matchQuery = {};
 
     // SAFE fuzzy searches
-    if (country)
-      matchQuery.countryName = { $regex: escapeRegex(country), $options: "i" };
+    if (country) {
+      const countries = Array.isArray(country) ? country : [country];
+
+      matchQuery.countryName = {
+        $in: countries.map((c) => ({
+          $regex: `^${escapeRegex(c.trim())}$`,
+          $options: "i",
+        })),
+      };
+    }
+
     if (gender)
-      matchQuery.gender = { $regex: escapeRegex(gender), $options: "i" };
+      matchQuery.gender = { $regex: `^${escapeRegex(gender)}$`, $options: "i" };
     if (roleType)
       matchQuery.roleType = { $regex: escapeRegex(roleType), $options: "i" };
-    if (role)
-      matchQuery.role = { $regex: escapeRegex(role), $options: "i" };
+    if (role) matchQuery.role = { $regex: escapeRegex(role), $options: "i" };
     if (soloProjectTier)
       matchQuery.soloProjectTier = {
         $regex: escapeRegex(soloProjectTier),
@@ -79,7 +86,7 @@ const getChingus = async (req, res) => {
       role,
       soloProjectTier,
       voyageTier,
-      voyage,       // exact match
+      voyage, // exact match
       yearJoined,
       page = 1,
       limit = 20,
@@ -95,21 +102,26 @@ const getChingus = async (req, res) => {
     // SAFE fuzzy searches
     if (country)
       query.countryName = { $regex: escapeRegex(country), $options: "i" };
-    if (gender)
-      query.gender = { $regex: escapeRegex(gender), $options: "i" };
+
+    if (gender) {
+      query.gender = { $regex: `^${escapeRegex(gender)}$`, $options: "i" };
+    }
+
     if (roleType)
       query.roleType = { $regex: escapeRegex(roleType), $options: "i" };
-    if (role)
-      query.role = { $regex: escapeRegex(role), $options: "i" };
+
+    if (role) query.role = { $regex: escapeRegex(role), $options: "i" };
+
     if (soloProjectTier)
       query.soloProjectTier = {
         $regex: escapeRegex(soloProjectTier),
         $options: "i",
       };
+
     if (voyageTier)
       query.voyageTier = { $regex: escapeRegex(voyageTier), $options: "i" };
 
-    // ❗ Exact match recommended for voyage IDs
+    // Exact match for voyage IDs
     if (voyage) query.voyage = voyage;
 
     // Exact numeric match

--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -105,7 +105,7 @@ const getChingus = async (req, res) => {
 
       query.$or = countries.map((c) => ({
         countryName: {
-          $regex: escapeRegex(String(c).trim()), 
+          $regex: escapeRegex(String(c).trim()),
           $options: "i",
         },
       }));

--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -24,7 +24,7 @@ const aggregateByCountry = async (req, res) => {
 
       matchQuery.$or = countries.map((c) => ({
         countryName: {
-          $regex: escapeRegex(c.trim()), // fuzzy contains search
+          $regex: escapeRegex(String(c).trim()), // fuzzy contains search
           $options: "i",
         },
       }));

--- a/backend/src/controllers/memberController.js
+++ b/backend/src/controllers/memberController.js
@@ -18,7 +18,7 @@ const aggregateByCountry = async (req, res) => {
 
     const matchQuery = {};
 
-    // SAFE fuzzy searches
+    // SAFE regex searches (fuzzy for most fields, exact for gender)
     if (country) {
       const countries = Array.isArray(country) ? country : [country];
 

--- a/backend/src/tests/aggregateByCountry.test.js
+++ b/backend/src/tests/aggregateByCountry.test.js
@@ -76,7 +76,7 @@ describe("GET /api/chingus/aggregate-by-country", () => {
             },
           ],
           gender: {
-            $regex: "^" + escapeRegex("female?") + "$",
+            $regex: `^${escapeRegex("female?")}$`,
             $options: "i",
           },
           voyage: "V58",

--- a/backend/src/tests/aggregateByCountry.test.js
+++ b/backend/src/tests/aggregateByCountry.test.js
@@ -55,7 +55,7 @@ describe("GET /api/chingus/aggregate-by-country", () => {
     ]);
   });
 
-  test("should apply sanitized exact filters + exact voyage + numeric yearJoined", async () => {
+  test("should apply sanitized fuzzy filters + exact voyage + numeric yearJoined", async () => {
     Chingu.aggregate.mockResolvedValue([]);
 
     const res = await request(app).get(
@@ -67,14 +67,14 @@ describe("GET /api/chingus/aggregate-by-country", () => {
     expect(Chingu.aggregate).toHaveBeenCalledWith([
       {
         $match: {
-          countryName: {
-            $in: [
-              {
-                $regex: "^" + escapeRegex("ind.") + "$",
+          $or: [
+            {
+              countryName: {
+                $regex: escapeRegex("ind."),
                 $options: "i",
               },
-            ],
-          },
+            },
+          ],
           gender: {
             $regex: "^" + escapeRegex("female?") + "$",
             $options: "i",
@@ -100,7 +100,7 @@ describe("GET /api/chingus/aggregate-by-country", () => {
     ]);
   });
 
-  test("should support multiple countries using $in", async () => {
+  test("should support multiple countries using $or", async () => {
     Chingu.aggregate.mockResolvedValue([]);
 
     const res = await request(app).get(
@@ -113,12 +113,20 @@ describe("GET /api/chingus/aggregate-by-country", () => {
       expect.arrayContaining([
         expect.objectContaining({
           $match: {
-            countryName: {
-              $in: [
-                { $regex: "^Tanzania$", $options: "i" },
-                { $regex: "^Kenya$", $options: "i" },
-              ],
-            },
+            $or: [
+              {
+                countryName: {
+                  $regex: escapeRegex("Tanzania"),
+                  $options: "i",
+                },
+              },
+              {
+                countryName: {
+                  $regex: escapeRegex("Kenya"),
+                  $options: "i",
+                },
+              },
+            ],
           },
         }),
       ])

--- a/backend/src/tests/chingu.test.js
+++ b/backend/src/tests/chingu.test.js
@@ -77,8 +77,11 @@ describe("GET /api/chingus", () => {
   });
 
   // ------------------------------------------------
-  // OTHER FUZZY FIELDS — DIRECT REGEX (NO $or)
+  // OTHER FIELDS — DIRECT REGEX (NO $or)
   // ------------------------------------------------
+  // Note: Country uses multi-value partial/fuzzy matching ($or).
+  //       Other fields below use direct regex matching (may be partial or exact).
+  //       Gender now uses exact match (with ^ and $ anchors in the controller).
 
   const directFuzzyFields = [
     { key: "roleType", mongo: "roleType" },

--- a/backend/src/tests/chingu.test.js
+++ b/backend/src/tests/chingu.test.js
@@ -50,7 +50,6 @@ describe("GET /api/chingus", () => {
   // ---------------------------
   const fuzzyFields = [
   { key: "country", mongo: "countryName" },
-  { key: "gender", mongo: "gender" },
   { key: "roleType", mongo: "roleType" },
   { key: "role", mongo: "role" },
   { key: "soloProjectTier", mongo: "soloProjectTier" },


### PR DESCRIPTION
What this pr do : 
i.  Removes fuzzy search from the /api/chingus and /api/aggregate-by-country 
<img width="1224" height="838" alt="Screenshot 2025-12-03 091619" src="https://github.com/user-attachments/assets/9f738ee6-7ab9-4246-ba8d-a0ed98084db8" />
<img width="1227" height="848" alt="Screenshot 2025-12-03 091650" src="https://github.com/user-attachments/assets/9aca604a-b2a7-467f-9b83-dcc2458a7a6e" />

ii. Enabled aggregate more than one country  in the result of the filter option 
<img width="1324" height="830" alt="Screenshot 2025-12-03 092251" src="https://github.com/user-attachments/assets/64c7344b-cf88-45b5-9bbf-e38484dc3c3f" />
